### PR TITLE
cflags should end with a space, so other mruby gems can add custom flags

### DIFF
--- a/lib/webruby/config.rb
+++ b/lib/webruby/config.rb
@@ -20,7 +20,7 @@ module Webruby
     end
 
     def cflags
-      "-Wall -Werror-implicit-function-declaration -Wno-warn-absolute-paths #{optimization_flag}"
+      "-Wall -Werror-implicit-function-declaration -Wno-warn-absolute-paths #{optimization_flag} "
     end
 
     def ldflags


### PR DESCRIPTION
When other mruby gems have custom cc.flags, like the following:

```
spec.cc.flags << '-D' // any flag, really
```

The compilation fails because the last webruby cc.flag mixes with the first of the mruby gem flags.
