### PR TITLE
More control over the print_level

### DIFF
--- a/scripts/gen_post.rb
+++ b/scripts/gen_post.rb
@@ -38,7 +38,7 @@ File.open(OUTPUT_JS_TEMP_FILE, 'w') do |f|
     opts = opts || {};
 
     // Default print level is errors only
-    this.print_level = opts.print_level || 1;
+    this.print_level = (opts.print_level >= 0) ? opts.print_level : 1;
     this.mrb = _mrb_open();
     _webruby_internal_setup(this.mrb);
   };
@@ -48,6 +48,9 @@ File.open(OUTPUT_JS_TEMP_FILE, 'w') do |f|
   };
   WEBRUBY.prototype.run = function() {
     _webruby_internal_run(this.mrb, this.print_level);
+  };
+  WEBRUBY.prototype.set_print_level = function(level) {
+    if (level >= 0) this.print_level = level;
   };
 __EOF__
 

--- a/scripts/gen_post.rb
+++ b/scripts/gen_post.rb
@@ -38,7 +38,10 @@ File.open(OUTPUT_JS_TEMP_FILE, 'w') do |f|
     opts = opts || {};
 
     // Default print level is errors only
-    this.print_level = (opts.print_level >= 0) ? opts.print_level : 1;
+    this.print_level = 1;
+    if (typeof opts.print_level === "number" && opts.print_level >= 0) {
+      this.print_level = opts.print_level;
+    }
     this.mrb = _mrb_open();
     _webruby_internal_setup(this.mrb);
   };


### PR DESCRIPTION
The latest improvements to the debug information of webruby works beautifully, but the information is displayed by default due a bug in `scripts/gen_post.rb`. This PR includes a fix to this bug, but also adds a public function to alter the value of `print_level`, so independent calls can have different debug information.